### PR TITLE
Fix for gulp-connect root path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('default', ['build:ng2']);
 
 gulp.task('connect', function() {
   connect.server({
-    root: '.',
+    root: __dirname,
     port: port,
     livereload: true
   });


### PR DESCRIPTION
Same as here https://github.com/AveVlad/gulp-connect/issues/54.

Error: Forbidden
    at createError (/ng2do/node_modules/gulp-connect/node_modules/connect/node_modules/serve-index/index.js:188:13)
